### PR TITLE
Minor UI and service component handling improvements

### DIFF
--- a/examples/gui/basic_radio/render_basic_radio.cpp
+++ b/examples/gui/basic_radio/render_basic_radio.cpp
@@ -119,7 +119,7 @@ void RenderSimple_ServiceList(BasicRadio& radio, BasicRadioViewController& contr
                     is_decode_data  ? ICON_FA_DOWNLOAD  : ""
                 );
 
-                const float offset = ImGui::GetWindowWidth() - ImGui::CalcTextSize(status_str.c_str()).x;
+                const float offset = ImGui::GetWindowContentRegionMax().x - ImGui::CalcTextSize(status_str.c_str()).x;
                 ImGui::SameLine(offset);
                 ImGui::Text("%.*s", int(status_str.length()), status_str.c_str());
             }
@@ -244,7 +244,8 @@ void RenderSimple_ServiceComponent(BasicRadio& radio, BasicRadioViewController& 
             FIELD_MACRO("Label", "%.*s", int(component.label.length()), component.label.c_str());
             FIELD_MACRO("Short Label", "%.*s", int(component.short_label.length()), component.short_label.c_str());
             FIELD_MACRO("Component ID", "%u (0x%01X)", component.component_id, component.component_id);
-            FIELD_MACRO("Global ID", "%u (0x%03X)", component.global_id, component.global_id);
+            if(component.global_id != 0xFFFF)
+                FIELD_MACRO("Global ID", "%u (0x%03X)", component.global_id, component.global_id);
             FIELD_MACRO("Subchannel ID", "%u (0x%02X)", component.subchannel_id, component.subchannel_id);
             FIELD_MACRO("Transport Mode", "%s", GetTransportModeString(component.transport_mode));
             FIELD_MACRO("Type", "%s", type_str);

--- a/src/basic_radio/basic_data_packet_channel.cpp
+++ b/src/basic_radio/basic_data_packet_channel.cpp
@@ -17,8 +17,8 @@
 #define LOG_MESSAGE(...) BASIC_RADIO_LOG_MESSAGE(fmt::format(__VA_ARGS__))
 #define LOG_ERROR(...) BASIC_RADIO_LOG_ERROR(fmt::format(__VA_ARGS__))
 
-Basic_Data_Packet_Channel::Basic_Data_Packet_Channel(const DAB_Parameters& params, Subchannel subchannel, DataServiceType type)
-: m_params(params), m_subchannel(subchannel), m_type(type)
+Basic_Data_Packet_Channel::Basic_Data_Packet_Channel(const DAB_Parameters& params, Subchannel subchannel, packet_addr_t packet_addr, DataServiceType type)
+: m_params(params), m_subchannel(subchannel), m_packet_addr(packet_addr), m_type(type)
 {
     assert(subchannel.is_complete);
     assert(subchannel.fec_scheme != FEC_Scheme::UNDEFINED);
@@ -81,7 +81,7 @@ void Basic_Data_Packet_Channel::ProcessFECPackets(tcb::span<const uint8_t> buf) 
 
 void Basic_Data_Packet_Channel::ProcessNonFECPackets(tcb::span<const uint8_t> buf) {
     while (!buf.empty()) {
-        const size_t total_read = m_msc_data_packet_processor->ReadPacket(buf);
+        const size_t total_read = m_msc_data_packet_processor->ReadPacket(buf, m_packet_addr);
         assert(total_read <= buf.size());
         buf = buf.subspan(total_read);
     }

--- a/src/basic_radio/basic_data_packet_channel.h
+++ b/src/basic_radio/basic_data_packet_channel.h
@@ -20,6 +20,7 @@ class Basic_Data_Packet_Channel: public Basic_MSC_Runner
 private:
     const DAB_Parameters m_params;
     const Subchannel m_subchannel;
+    const packet_addr_t m_packet_addr;
     const DataServiceType m_type;
     std::unique_ptr<MSC_Decoder> m_msc_decoder;
     std::unique_ptr<MSC_Data_Packet_Processor> m_msc_data_packet_processor;
@@ -27,7 +28,7 @@ private:
     std::unique_ptr<Basic_Slideshow_Manager> m_slideshow_manager;
     Observable<MOT_Entity> m_obs_MOT_entity;
 public:
-    explicit Basic_Data_Packet_Channel(const DAB_Parameters& params, Subchannel subchannel, DataServiceType type);
+    explicit Basic_Data_Packet_Channel(const DAB_Parameters& params, Subchannel subchannel, packet_addr_t packet_addr, DataServiceType type);
     ~Basic_Data_Packet_Channel() override;
     void Process(tcb::span<const viterbi_bit_t> msc_bits_buf) override;
     auto& GetSlideshowManager() { return *m_slideshow_manager; }

--- a/src/basic_radio/basic_radio.cpp
+++ b/src/basic_radio/basic_radio.cpp
@@ -119,6 +119,7 @@ void BasicRadio::UpdateAfterProcessing() {
         const auto mode = service_component->transport_mode;
         const auto audio_type = service_component->audio_service_type;
         const auto data_type = service_component->data_service_type;
+        const auto packet_addr = service_component->packet_address;
 
         if (audio_type == AudioServiceType::DAB_PLUS && mode == TransportMode::STREAM_MODE_AUDIO) {
             LOG_MESSAGE("Added DAB+ subchannel {}", subchannel.id);
@@ -143,7 +144,7 @@ void BasicRadio::UpdateAfterProcessing() {
         // Data packet channels require the FEC scheme to be defined for outer encoding
         if (mode == TransportMode::PACKET_MODE_DATA && (subchannel.fec_scheme != FEC_Scheme::UNDEFINED)) {
             LOG_MESSAGE("Added data packet subchannel {}", subchannel.id);
-            auto channel = std::make_shared<Basic_Data_Packet_Channel>(m_params, subchannel, data_type);
+            auto channel = std::make_shared<Basic_Data_Packet_Channel>(m_params, subchannel, packet_addr, data_type);
             m_msc_runners.insert({ subchannel.id, channel });
             m_data_packet_channels.insert({ subchannel.id, channel });
             m_obs_data_packet_channel.Notify(subchannel.id, *channel);

--- a/src/dab/database/dab_database_entities.h
+++ b/src/dab/database/dab_database_entities.h
@@ -82,8 +82,9 @@ struct ServiceComponent {
     service_id_t service_reference;   
     service_component_id_t component_id;         
     // Method 2: SCId global identifier used for packet mode
-    service_component_global_id_t global_id = 0;          
+    service_component_global_id_t global_id = 0xFFFF;                   // required for transport packet data
     subchannel_id_t subchannel_id = 0;                                  // required 
+    packet_addr_t packet_address = 0;                                   // required for transport packet data
     std::string label;
     std::string short_label;
     TransportMode transport_mode = TransportMode::UNDEFINED;            // required

--- a/src/dab/database/dab_database_types.h
+++ b/src/dab/database/dab_database_types.h
@@ -16,6 +16,7 @@ typedef uint8_t  extended_country_id_t;     // 8bits
 typedef uint8_t  language_id_t;             // 8bits
 typedef uint8_t  programme_id_t;            // 5bits
 typedef uint8_t  closed_caption_id_t;       // 8bits
+typedef uint16_t packet_addr_t;             // 10bits
 
 typedef uint16_t subchannel_addr_t;         // 10bits
 typedef uint16_t subchannel_size_t;         // 10bits (in capacity units)

--- a/src/dab/database/dab_database_updater.h
+++ b/src/dab/database/dab_database_updater.h
@@ -159,6 +159,7 @@ public:
     UpdateResult SetAudioServiceType(const AudioServiceType audio_service_type);
     UpdateResult SetDataServiceType(const DataServiceType data_service_type);
     UpdateResult SetSubchannel(const subchannel_id_t subchannel_id);
+    UpdateResult SetPacketAddr(const packet_addr_t packet_addr);
     UpdateResult SetGlobalID(const service_component_global_id_t global_id);
     uint32_t GetServiceReference();
     auto& GetData() { return m_db.service_components[m_index]; }
@@ -296,6 +297,7 @@ public:
     OtherEnsembleUpdater& GetOtherEnsemble(const ensemble_id_t ensemble_reference);
     ServiceComponentUpdater* GetServiceComponentUpdater_GlobalID(const service_component_global_id_t global_id);
     ServiceComponentUpdater* GetServiceComponentUpdater_Subchannel(const subchannel_id_t subchannel_id);
+    ServiceComponentUpdater* GetServiceComponentUpdater_Subchannel(const service_id_t service_ref, const subchannel_id_t subchannel_id);
     const auto& GetDatabase() const { return *(m_db.get()); }
     const auto& GetStatistics() const { return *(m_stats.get()); }
 private:

--- a/src/dab/fic/fig_processor.cpp
+++ b/src/dab/fic/fig_processor.cpp
@@ -408,20 +408,20 @@ void FIG_Processor::ProcessFIG_Type_0_Ext_2(const FIG_Header_Type_0 header, tcb:
             // MSC stream audio
             case 0b00:
                 {
-                    const uint8_t ASTCy         = (b0 & 0b00111111) >> 0;
+                    const uint8_t ASCTy         = (b0 & 0b00111111) >> 0;
                     const uint8_t subchannel_id = (b1 & 0b11111100) >> 2;
                     const uint8_t is_primary    = (b1 & 0b00000010) >> 1;
                     const uint8_t ca_flag       = (b1 & 0b00000001) >> 0;
-                    LOG_MESSAGE("fig 0/2 pd={} country_id={:>2} service_ref={:>4} ecc={} i={}-{}/{} tmid={} ASTCy={} subchannel_id={:>2} ps={} ca={}",
+                    LOG_MESSAGE("fig 0/2 pd={} country_id={:>2} service_ref={:>4} ecc={} i={}-{}/{} tmid={} ASCTy={} subchannel_id={:>2} ps={} ca={}",
                         header.pd,
                         sid.country_id, sid.service_reference, sid.ecc,
                         curr_service, i, nb_service_components,
                         tmid, 
-                        ASTCy, subchannel_id, is_primary, ca_flag);
+                        ASCTy, subchannel_id, is_primary, ca_flag);
                     
                     m_handler->OnServiceComponent_1_StreamAudioType(
                         sid.country_id, sid.service_reference, sid.ecc,
-                        subchannel_id, ASTCy, is_primary);
+                        subchannel_id, ASCTy, is_primary);
                 }
                 break;
             // MSC stream data

--- a/src/dab/msc/msc_data_packet_processor.h
+++ b/src/dab/msc/msc_data_packet_processor.h
@@ -3,7 +3,6 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <vector>
-#include <optional>
 #include <memory>
 #include "utility/span.h"
 
@@ -12,7 +11,6 @@ class MOT_Processor;
 class MSC_Data_Packet_Processor
 {
 private:
-    std::optional<uint16_t> m_last_address = std::nullopt;
     uint8_t m_last_continuity_index = 0;
     size_t m_total_packets = 0;
     std::vector<uint8_t> m_assembly_buffer;
@@ -20,7 +18,7 @@ private:
 public:
     MSC_Data_Packet_Processor();
     ~MSC_Data_Packet_Processor();
-    size_t ReadPacket(tcb::span<const uint8_t> buf);
+    size_t ReadPacket(tcb::span<const uint8_t> buf, uint16_t packet_addr);
     MOT_Processor& Get_MOT_Processor() const { return *m_mot_processor; }
 private:
     void PushPiece(tcb::span<const uint8_t> piece);


### PR DESCRIPTION
## Minor UI and service component handling improvements

------

### Changes

- Minor UI improvements in Services display
- Added support for `packet_address` in packet data mode
- Updated logic in `ServiceComponentUpdater` and `Radio_FIG_Handler`:
  - Avoids unintended database conflicts
  - Differentiates stream audio, stream data, and packet data modes
  - Adds mode-specific field validation

------

### Testing
- before (top) / after (bottom)
<img width="1280" height="561" alt="2025-08-07_14-22-45" src="https://github.com/user-attachments/assets/7c8140c2-46fa-4ca5-8291-62dd1956a8d2" />

<img width="1280" height="558" alt="2025-08-07_14-24-01" src="https://github.com/user-attachments/assets/f1087397-430b-45cd-8784-7175f7f4c322" />

Tested using:

- [`dab.2021-12-16T14_26_44_664`](https://github.com/HeisensOppings/DAB-Rawfiles)
  - Demonstrates multiple service components sharing the same `subchannel_id`.
 
<img width="651" height="579" alt="2025-08-07_13-54-50" src="https://github.com/user-attachments/assets/d45c7321-68c9-44af-a107-7656d5d10d70" />

- [`2023_12_24_09_36_55_2048000_fHz222064000`](https://github.com/HeisensOppings/DAB-Rawfiles)
  - Confirms `global_id == 0` is valid in packet data mode

<img width="652" height="586" alt="2025-08-07_13-54-17" src="https://github.com/user-attachments/assets/2fdb064e-e38f-4685-abda-1624c964e9d6" />

------

### Notes

- **Initialized `global_id` to `0xFFFF` instead of `0`**
  - `0` is valid for packet data mode and shouldn't imply uninitialized
  - Prevents `GetServiceComponentUpdater_GlobalID()` from mistakenly selecting stream-mode components

```cpp
struct ServiceComponent
    service_component_global_id_t global_id = 0xFFFF;
```

- **Support for service components sharing `subchannel_id`**
  Added `service_ref` condition to resolve conflicts more reliably:

```cpp
ServiceComponentUpdater* DAB_Database_Updater::GetServiceComponentUpdater_Subchannel(
    const service_id_t service_ref, const subchannel_id_t subchannel_id) 
{
    return find_updater(
        m_db->service_components, m_service_component_updaters,
        [service_ref, subchannel_id](const auto& e) {
            return (e.service_reference == service_ref) && (e.subchannel_id == subchannel_id);
        }
    );
}
```

------

### TODO

The current `FIG 0/5` handler assumes a 1:1 mapping between `subchannel_id` and service components.
However, some real-world cases involve multiple components sharing the same ID.

We might need something like:

```cpp
void Radio_FIG_Handler::OnServiceComponent_3_Short_Language(
    const uint8_t subchannel_id, const uint8_t language)
{
    if (!m_updater) return;
    for (auto& sc_u : m_updater->m_service_component_updaters)
    {
        if (sc_u.GetData().subchannel_id == subchannel_id)
            sc_u.SetLanguage(language);
    }
}
```

This is a rough suggestion — Not sure if this is the best way to integrate with the current updater model.

---

Please feel free to merge, modify, or skip any part that doesn't fit your design preference.