### PR TITLE
Improve FIG 0/17 handling and service component data

### DIFF
--- a/examples/gui/basic_radio/formatters.cpp
+++ b/examples/gui/basic_radio/formatters.cpp
@@ -74,6 +74,28 @@ const char* GetLanguageTypeString(language_id_t language_id) {
     return GetLanguageName(language_id).c_str();
 }
 
+const char* GetUserApplicationTypeString(const user_application_type_t application_type)
+{
+    switch (static_cast<UserApplicationType>(application_type)) {
+    case UserApplicationType::SLIDESHOW:
+        return "SlideShow";
+    case UserApplicationType::TPEG:
+        return "TPEG";
+    case UserApplicationType::SPI:
+        return "SPI";
+    case UserApplicationType::DMB:
+        return "DMB";
+    case UserApplicationType::FILE_CASTING:
+        return "Filecasting";
+    case UserApplicationType::FIS:
+        return "FIS";
+    case UserApplicationType::JOURNALINE:
+        return "Journaline®";
+    default:
+        return "Unknown";
+    }
+}
+
 const char* GetCountryString(extended_country_id_t ecc, country_id_t country_id) {
     return GetCountryName(ecc, country_id).c_str();
 }

--- a/examples/gui/basic_radio/formatters.h
+++ b/examples/gui/basic_radio/formatters.h
@@ -13,6 +13,7 @@ const char* GetAudioTypeString(const AudioServiceType audio_type);
 const char* GetDataTypeString(const DataServiceType data_type);
 const char* GetProgrammeTypeString(uint8_t inter_table_id, programme_id_t program_id);
 const char* GetLanguageTypeString(language_id_t language_id);
+const char* GetUserApplicationTypeString(const user_application_type_t application_type);
 const char* GetCountryString(extended_country_id_t ecc, country_id_t country_id);
 const char* GetAACDescriptionString(bool is_spectral_band_replication, bool is_parametric_stereo);
 const char* GetMPEGSurroundString(MPEG_Surround mpeg);

--- a/examples/gui/basic_radio/render_basic_radio.cpp
+++ b/examples/gui/basic_radio/render_basic_radio.cpp
@@ -175,8 +175,6 @@ void RenderSimple_Service(BasicRadio& radio, BasicRadioViewController& controlle
             FIELD_MACRO("Programme Type", "%s (%u)", 
                 GetProgrammeTypeString(ensemble.international_table_id, service->programme_type),
                 service->programme_type);
-            FIELD_MACRO("Language", "%s (%u)", GetLanguageTypeString(service->language), service->language);
-            FIELD_MACRO("Closed Caption", "%u", service->closed_caption);
 
             #undef FIELD_MACRO
 
@@ -253,11 +251,24 @@ void RenderSimple_ServiceComponent(BasicRadio& radio, BasicRadioViewController& 
             FIELD_MACRO("Label", "%.*s", int(component.label.length()), component.label.c_str());
             FIELD_MACRO("Short Label", "%.*s", int(component.short_label.length()), component.short_label.c_str());
             FIELD_MACRO("Component ID", "%u (0x%01X)", component.component_id, component.component_id);
-            if(component.global_id != 0xFFFF)
+            if(!is_audio_type)
                 FIELD_MACRO("Global ID", "%u (0x%03X)", component.global_id, component.global_id);
             FIELD_MACRO("Subchannel ID", "%u (0x%02X)", component.subchannel_id, component.subchannel_id);
             FIELD_MACRO("Transport Mode", "%s", GetTransportModeString(component.transport_mode));
             FIELD_MACRO("Type", "%s", type_str);
+            FIELD_MACRO("Language", "%s (%u)", GetLanguageTypeString(component.language), component.language);
+            if (!component.application_types.empty()) {
+                std::string formatted_types;
+                for (const auto& app_type : component.application_types) {
+                    if (!formatted_types.empty()) {
+                        formatted_types += ", ";
+                    }
+                    formatted_types += fmt::format("{} ({})",
+                        GetUserApplicationTypeString(app_type),
+                        app_type);
+                }
+                FIELD_MACRO("User Application Types", "%s", formatted_types.c_str());
+            }
 
             ImGui::EndTable();
         }

--- a/src/dab/database/dab_database_entities.h
+++ b/src/dab/database/dab_database_entities.h
@@ -45,6 +45,17 @@ enum class FEC_Scheme: uint8_t {        // Value passed in 4bit field
     UNDEFINED = 0xFF,
 };
 
+enum class UserApplicationType: uint16_t {  // Value passed in 11bit field
+    SLIDESHOW = 0x002,
+    TPEG = 0x004,
+    SPI = 0x007,
+    DMB = 0x009,
+    FILE_CASTING = 0x00D,
+    FIS = 0x00E,
+    JOURNALINE = 0x44A,
+    UNDEFINED = 0xFFFF,
+};
+
 // NOTE: A valid database entry exists when all the required fields are set
 // The required fields constraint is also followed in the dab_database_updater.cpp
 // when we are regenerating the database from the FIC (fast information channel)
@@ -138,8 +149,6 @@ struct Service {
     std::string label;
     std::string short_label;
     programme_id_t programme_type = 0;    
-    language_id_t language = 0;          
-    closed_caption_id_t closed_caption = 0;       
     bool is_complete = false;
     explicit Service(const ServiceId _id) : id(_id) {}
 };
@@ -155,9 +164,11 @@ struct ServiceComponent {
     packet_addr_t packet_address = 0;                                   // required for transport packet data
     std::string label;
     std::string short_label;
+    language_id_t language = 0;
+    std::vector<user_application_type_t> application_types;             // required for transport stream/packet data. (optional) for stream audio (XPAD often used for slideshows)
     TransportMode transport_mode = TransportMode::UNDEFINED;            // required
     AudioServiceType audio_service_type = AudioServiceType::UNDEFINED;  // required for transport stream audio
-    DataServiceType data_service_type = DataServiceType::UNDEFINED;     // (optional) for transport stream/packet data - we expect this to be provided but real world data doesn't
+    DataServiceType data_service_type = DataServiceType::UNDEFINED;     // required for transport stream/packet data
     bool is_complete = false;
     explicit ServiceComponent(
         const ServiceId _service_id, 

--- a/src/dab/database/dab_database_types.h
+++ b/src/dab/database/dab_database_types.h
@@ -5,27 +5,27 @@
 // The size of these fields were derived from the length of the bitfields that carry them
 // These are found in Clause 5.2 to Clause 8 
 
-typedef uint16_t ensemble_reference_t;      // 12bits
-typedef uint32_t service_reference_t;       // 12 to 20bits
-typedef uint8_t  service_component_id_t;    // 4bits
+typedef uint16_t ensemble_reference_t;          // 12bits
+typedef uint32_t service_reference_t;           // 12 to 20bits
+typedef uint8_t  service_component_id_t;        // 4bits
 typedef uint16_t service_component_global_id_t; // 12bits
-typedef uint8_t  subchannel_id_t;           // 6bits
+typedef uint8_t  subchannel_id_t;               // 6bits
 
-typedef uint8_t  country_id_t;              // 4bits
-typedef uint8_t  extended_country_id_t;     // 8bits
-typedef uint8_t  language_id_t;             // 8bits
-typedef uint8_t  programme_id_t;            // 5bits
-typedef uint8_t  closed_caption_id_t;       // 8bits
-typedef uint16_t packet_addr_t;             // 10bits
+typedef uint8_t  country_id_t;                  // 4bits
+typedef uint8_t  extended_country_id_t;         // 8bits
+typedef uint8_t  language_id_t;                 // 8bits
+typedef uint8_t  programme_id_t;                // 5bits
+typedef uint16_t packet_addr_t;                 // 10bits
+typedef uint16_t user_application_type_t;       // 11bits
 
-typedef uint16_t subchannel_addr_t;         // 10bits
-typedef uint16_t subchannel_size_t;         // 10bits (in capacity units)
-typedef uint8_t  eep_protection_level_t;    // 2bits (EEP) table index
-typedef uint8_t  uep_protection_index_t;    // 6bits (UEP) table index
+typedef uint16_t subchannel_addr_t;             // 10bits
+typedef uint16_t subchannel_size_t;             // 10bits (in capacity units)
+typedef uint8_t  eep_protection_level_t;        // 2bits (EEP) table index
+typedef uint8_t  uep_protection_index_t;        // 6bits (UEP) table index
 
-typedef uint16_t lsn_t;                     // 12bits (linkage set number)
-typedef uint16_t fm_id_t;                   // 16bits
-typedef uint32_t drm_id_t;                  // 24bits
-typedef uint32_t amss_id_t;                 // 24bits
+typedef uint16_t lsn_t;                         // 12bits (linkage set number)
+typedef uint16_t fm_id_t;                       // 16bits
+typedef uint32_t drm_id_t;                      // 24bits
+typedef uint32_t amss_id_t;                     // 24bits
 
-typedef uint32_t freq_t;                    // 32bit unsigned integer (Hz)
+typedef uint32_t freq_t;                        // 32bit unsigned integer (Hz)

--- a/src/dab/database/dab_database_updater.cpp
+++ b/src/dab/database/dab_database_updater.cpp
@@ -464,17 +464,6 @@ ServiceComponentUpdater* DAB_Database_Updater::GetServiceComponentUpdater_Global
 }
 
 ServiceComponentUpdater* DAB_Database_Updater::GetServiceComponentUpdater_Subchannel(
-    const subchannel_id_t subchannel_id) 
-{
-    return find_updater(
-        m_db->service_components, m_service_component_updaters,
-        [subchannel_id](const auto& e) {
-            return e.subchannel_id == subchannel_id;
-        }
-    );
-}
-
-ServiceComponentUpdater* DAB_Database_Updater::GetServiceComponentUpdater_Subchannel(
     const ServiceId service_id, const subchannel_id_t subchannel_id) 
 {
     const auto service_uuid = service_id.get_unique_identifier();

--- a/src/dab/database/dab_database_updater.cpp
+++ b/src/dab/database/dab_database_updater.cpp
@@ -71,9 +71,7 @@ bool EnsembleUpdater::IsComplete() {
 // Service form
 const uint8_t SERVICE_FLAG_LABEL        = 0b00100000;
 const uint8_t SERVICE_FLAG_PROGRAM_TYPE = 0b00010000;
-const uint8_t SERVICE_FLAG_LANGUAGE     = 0b00001000;
-const uint8_t SERVICE_FLAG_CLOSED_CAP   = 0b00000100;
-const uint8_t SERVICE_FLAG_SHORT_LABEL  = 0b00000010;
+const uint8_t SERVICE_FLAG_SHORT_LABEL  = 0b00001000;
 const uint8_t SERVICE_FLAG_REQUIRED     = 0b00000000;
 
 UpdateResult ServiceUpdater::SetLabel(std::string_view label) {
@@ -88,31 +86,25 @@ UpdateResult ServiceUpdater::SetProgrammeType(const programme_id_t programme_typ
     return UpdateField(GetData().programme_type, programme_type, SERVICE_FLAG_PROGRAM_TYPE);
 }
 
-UpdateResult ServiceUpdater::SetLanguage(const language_id_t language) {
-    return UpdateField(GetData().language, language, SERVICE_FLAG_LANGUAGE);
-}
-
-UpdateResult ServiceUpdater::SetClosedCaption(const closed_caption_id_t closed_caption) {
-    return UpdateField(GetData().closed_caption, closed_caption, SERVICE_FLAG_CLOSED_CAP);
-}
-
 bool ServiceUpdater::IsComplete() {
     return GetData().is_complete = ((m_dirty_field & SERVICE_FLAG_REQUIRED) == SERVICE_FLAG_REQUIRED);
 }
 
 // Service component form
-const uint8_t SERVICE_COMPONENT_FLAG_LABEL                 = 0b10000000;
-const uint8_t SERVICE_COMPONENT_FLAG_TRANSPORT_MODE        = 0b01000000;
-const uint8_t SERVICE_COMPONENT_FLAG_AUDIO_TYPE            = 0b00100000;
-const uint8_t SERVICE_COMPONENT_FLAG_DATA_TYPE             = 0b00010000;
-const uint8_t SERVICE_COMPONENT_FLAG_SUBCHANNEL            = 0b00001000;
-const uint8_t SERVICE_COMPONENT_FLAG_GLOBAL_ID             = 0b00000100;
-const uint8_t SERVICE_COMPONENT_FLAG_SHORT_LABEL           = 0b00000010;
-const uint8_t SERVICE_COMPONENT_FLAG_PACKET_ADDRESS        = 0b00000001;
+const uint16_t SERVICE_COMPONENT_FLAG_LABEL                 = 0b1000000000;
+const uint16_t SERVICE_COMPONENT_FLAG_TRANSPORT_MODE        = 0b0100000000;
+const uint16_t SERVICE_COMPONENT_FLAG_AUDIO_TYPE            = 0b0010000000;
+const uint16_t SERVICE_COMPONENT_FLAG_DATA_TYPE             = 0b0001000000;
+const uint16_t SERVICE_COMPONENT_FLAG_SUBCHANNEL            = 0b0000100000;
+const uint16_t SERVICE_COMPONENT_FLAG_GLOBAL_ID             = 0b0000010000;
+const uint16_t SERVICE_COMPONENT_FLAG_SHORT_LABEL           = 0b0000001000;
+const uint16_t SERVICE_COMPONENT_FLAG_PACKET_ADDRESS        = 0b0000000100;
+const uint16_t SERVICE_COMPONENT_FLAG_LANGUAGE              = 0b0000000010;
+const uint16_t SERVICE_COMPONENT_FLAG_APPLICATION_TYPE      = 0b0000000001;
 // A different set of required fields applies to stream audio, stream data, and packet data components.
-const uint8_t SERVICE_COMPONENT_FLAG_REQUIRED_STREAM_AUDIO = 0b01101000;
-const uint8_t SERVICE_COMPONENT_FLAG_REQUIRED_STREAM_DATA  = 0b01011000;
-const uint8_t SERVICE_COMPONENT_FLAG_REQUIRED_PACKET_DATA  = 0b01011001;
+const uint16_t SERVICE_COMPONENT_FLAG_REQUIRED_STREAM_AUDIO = 0b0110100000;
+const uint16_t SERVICE_COMPONENT_FLAG_REQUIRED_STREAM_DATA  = 0b0101100000;
+const uint16_t SERVICE_COMPONENT_FLAG_REQUIRED_PACKET_DATA  = 0b0101100101;
 
 UpdateResult ServiceComponentUpdater::SetLabel(std::string_view label) {
     return UpdateField(GetData().label, label, SERVICE_COMPONENT_FLAG_LABEL);
@@ -148,6 +140,18 @@ UpdateResult ServiceComponentUpdater::SetSubchannel(const subchannel_id_t subcha
 
 UpdateResult ServiceComponentUpdater::SetPacketAddr(const packet_addr_t packet_addr) {
     return UpdateField(GetData().packet_address, packet_addr, SERVICE_COMPONENT_FLAG_PACKET_ADDRESS);
+}
+
+UpdateResult ServiceComponentUpdater::SetLanguage(const language_id_t language) {
+    return UpdateField(GetData().language, language, SERVICE_COMPONENT_FLAG_LANGUAGE);
+}
+
+UpdateResult ServiceComponentUpdater::AddUserApplicationType(const user_application_type_t application_type) {
+    if (!insert_if_unique(GetData().application_types, application_type)) return UpdateResult::NO_CHANGE;
+    m_dirty_field |= SERVICE_COMPONENT_FLAG_APPLICATION_TYPE;
+    OnComplete();
+    OnUpdate();
+    return UpdateResult::SUCCESS;
 }
 
 UpdateResult ServiceComponentUpdater::SetGlobalID(const service_component_global_id_t global_id) {

--- a/src/dab/database/dab_database_updater.h
+++ b/src/dab/database/dab_database_updater.h
@@ -290,7 +290,6 @@ public:
     AMSS_ServiceUpdater& GetAMSS_ServiceUpdater(const amss_id_t amss_code);
     OtherEnsembleUpdater& GetOtherEnsemble(const EnsembleId ensemble_id);
     ServiceComponentUpdater* GetServiceComponentUpdater_GlobalID(const service_component_global_id_t global_id);
-    ServiceComponentUpdater* GetServiceComponentUpdater_Subchannel(const subchannel_id_t subchannel_id);
     ServiceComponentUpdater* GetServiceComponentUpdater_Subchannel(const ServiceId service_id, const subchannel_id_t subchannel_id);
     template <typename Fn>
     void ForEachServiceComponentUpdater_Subchannel(const subchannel_id_t subchannel_id, Fn&& fn) {

--- a/src/dab/database/dab_database_updater.h
+++ b/src/dab/database/dab_database_updater.h
@@ -135,21 +135,19 @@ public:
     UpdateResult SetLabel(std::string_view label);
     UpdateResult SetShortLabel(std::string_view short_label);
     UpdateResult SetProgrammeType(const programme_id_t programme_type);
-    UpdateResult SetLanguage(const language_id_t language);
-    UpdateResult SetClosedCaption(const closed_caption_id_t closed_caption);
     auto& GetData() { return m_db.services[m_index]; }
 private:
     bool IsComplete() override;
 };
 
-class ServiceComponentUpdater: private DatabaseEntityUpdater<uint8_t>
+class ServiceComponentUpdater: private DatabaseEntityUpdater<uint16_t>
 {
 private:
     DAB_Database& m_db;
     const size_t m_index;
 public:
     explicit ServiceComponentUpdater(DAB_Database& db, size_t index, DatabaseUpdaterGlobalStatistics& stats)
-        : DatabaseEntityUpdater<uint8_t>(stats), m_db(db), m_index(index) { OnCreate(); }
+        : DatabaseEntityUpdater<uint16_t>(stats), m_db(db), m_index(index) { OnCreate(); }
     UpdateResult SetLabel(std::string_view label);
     UpdateResult SetShortLabel(std::string_view short_label);
     UpdateResult SetTransportMode(const TransportMode transport_mode);
@@ -157,6 +155,8 @@ public:
     UpdateResult SetDataServiceType(const DataServiceType data_service_type);
     UpdateResult SetSubchannel(const subchannel_id_t subchannel_id);
     UpdateResult SetPacketAddr(const packet_addr_t packet_addr);
+    UpdateResult SetLanguage(const language_id_t language);
+    UpdateResult AddUserApplicationType(const user_application_type_t application_type);
     UpdateResult SetGlobalID(const service_component_global_id_t global_id);
     auto& GetData() { return m_db.service_components[m_index]; }
 private:
@@ -292,6 +292,22 @@ public:
     ServiceComponentUpdater* GetServiceComponentUpdater_GlobalID(const service_component_global_id_t global_id);
     ServiceComponentUpdater* GetServiceComponentUpdater_Subchannel(const subchannel_id_t subchannel_id);
     ServiceComponentUpdater* GetServiceComponentUpdater_Subchannel(const ServiceId service_id, const subchannel_id_t subchannel_id);
+    template <typename Fn>
+    void ForEachServiceComponentUpdater_Subchannel(const subchannel_id_t subchannel_id, Fn&& fn) {
+        for_each_updater(
+            m_db->service_components, m_service_component_updaters,
+            [subchannel_id](const auto& e) { return e.subchannel_id == subchannel_id; },
+            std::forward<Fn>(fn)
+        );
+    }
+    template <typename Fn>
+    void ForEachServiceComponentUpdater_GlobalID(const service_component_global_id_t global_id, Fn&& fn) {
+        for_each_updater(
+            m_db->service_components, m_service_component_updaters,
+            [global_id](const auto& e) { return e.global_id == global_id; },
+            std::forward<Fn>(fn)
+        );
+    }
     const auto& GetDatabase() const { return *(m_db.get()); }
     const auto& GetStatistics() const { return *(m_stats.get()); }
 private:
@@ -322,5 +338,16 @@ private:
             return nullptr;
         }
         return &updaters[index];
+    }
+
+    template <typename T, typename U, typename F, typename Fn>
+    void for_each_updater(std::vector<T>& entries, std::vector<U>& updaters, F&& match_func, Fn&& action_func) {
+        assert(entries.size() == updaters.size());
+        const size_t N = entries.size();
+        for (size_t i = 0; i < N; i++) {
+            if (match_func(entries[i])) {
+                action_func(updaters[i]);
+            }
+        }
     }
 };

--- a/src/dab/fic/fig_handler_interface.h
+++ b/src/dab/fic/fig_handler_interface.h
@@ -115,9 +115,7 @@ public:
     // fig 0/17 - Programme type
     virtual void OnService_1_ProgrammeType(
         const ServiceId service_id,
-        const uint8_t programme_type, 
-        const uint8_t language_type,  const uint8_t closed_caption_type,
-        const bool has_language=false, const bool has_closed_caption=false) = 0;
+        const uint8_t programme_type) = 0;
     // fig 0/21 - Alternate frequency information
     virtual void OnFrequencyInformation_1_Ensemble(
         const EnsembleId ensemble_id,

--- a/src/dab/radio_fig_handler.h
+++ b/src/dab/radio_fig_handler.h
@@ -123,9 +123,7 @@ public:
     // fig 0/17 - Programme type
     void OnService_1_ProgrammeType(
         const ServiceId service_id,
-        const uint8_t programme_type, 
-        const uint8_t language_type,  const uint8_t closed_caption_type,
-        const bool has_language=false, const bool has_closed_caption=false) override;
+        const uint8_t programme_type) override;
     // fig 0/21 - Alternate frequency information
     void OnFrequencyInformation_1_Ensemble(
         const EnsembleId ensemble_id,


### PR DESCRIPTION
## Improve FIG 0/17 handling and service component data

#### Changes

- Drop **CC** and **language** from FIG 0/17 in OnService_1_ProgrammeType.
- Move **language field** from `service` to `service component`.
- Add **user application type** for service component.
- Add `ForEachServiceComponentUpdater_xxx` helpers for traversing service components.

Test Rawfile [2024_10_11_18_49_27_2048000_11D_fHz222064000.raw](https://github.com/HeisensOppings/DAB-Rawfiles/releases/download/Assets/2024_10_11_18_49_27_2048000_11D_fHz222064000.raw)
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/24a91c44-2700-4ee1-bfbd-6199a0440641" />

#### References

[ETSI EN 300 401 V1.4.1 2006](https://www.etsi.org/deliver/etsi_en/300400_300499/300401/01.04.01_60/en_300401v010401p.pdf)
[ETSI EN 300 401 V2.1.1 2017](https://www.etsi.org/deliver/etsi_en/300400_300499/300401/02.01.01_60/en_300401v020101p.pdf)
[WorldDAB](https://www.worlddab.org/system/news/documents/000/007/291/original/TCstandard_FINAL.pdf?1485961433)
[Update of the DAB system standard EN 300 401](https://gallery.mailchimp.com/0b6e5d905a4bc37455ae88b71/files/a6123ae7-e470-40fa-8b83-f46ad2600776/Update_to_DAB_system_standard_EN_300_401.pdf?utm_source=Members+Newsletter&utm_campaign=ec1425c5a9-WorldDAB+Members+Newsletter+-++February+2017&utm_medium=email&utm_term=0_e028427777-ec1425c5a9-%5BLIST_EMAIL_ID%5D&ct=t%28WorldDAB+Members+Newsletter+-+February+2017%29)

### Notes

- The **Update to DAB system standard EN 300 401** specifies:
  - FIG 0/17 (Programme Type): language field removed as feature provided by FIG 0/5; second code removed;

Please review and feel free to **merge, modify, or skip** any part that doesn’t align with your design.
If I misunderstood part of the spec, please correct me.